### PR TITLE
🐛 fix a recursion 💩 that caused exponential growth of the call stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ npm-debug.log
 # misc. temp files
 tmp
 **/test.log
+
+# jest crash logs
+report.*.json

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -332,13 +332,15 @@ function isVNode(maybeNode: ComponentChild): maybeNode is VNode<unknown> {
   );
 }
 
-function childrenToTree(children: ComponentChild, root: Root<any>) {
-  return array(children).reduce(
-    (accumulator: {children: NodeTree, descendants: NodeTree}, next: ComponentChild) => {
-      accumulator.children.push(buildElementWrappers(next, root)[0]);
-      accumulator.descendants.push(...buildElementWrappers(next, root));
-      return accumulator;
-    },
-    {children: [] as NodeTree, descendants: [] as NodeTree},
-  );
+function childrenToTree(inputChildren: ComponentChild, root: Root<any>) {
+  const children: NodeTree = [];
+  const descendants: NodeTree = [];
+  
+  for (const child of array(inputChildren)) {
+    const wrappers = buildElementWrappers(child, root);
+    children.push(wrappers[0]);
+    descendants.push(...wrappers);
+  }
+  
+  return {children, descendants};
 }

--- a/src/tests/e2e.test.tsx
+++ b/src/tests/e2e.test.tsx
@@ -5,15 +5,26 @@ import {
   Component,
   Fragment,
   Ref,
-  render,
 } from 'preact';
-import {memo, PureComponent, forwardRef} from 'preact/compat';
+import {memo, PureComponent, forwardRef, render} from 'preact/compat';
 import {useState, useEffect, useContext} from 'preact/hooks';
 import {createPortal} from 'preact/compat';
 import {mount, createMount} from '../mount';
 import {ComponentType} from '../types';
 
 describe('@shopify/preact-testing', () => {
+  it('does not time out with large trees', () => {
+    function RecurseMyself({children, times}: any) {
+      if (times <= 0) {
+        return <div>finished</div>;
+      }
+      return <RecurseMyself times={times - 1} />;
+    }
+    expect(() => {
+      mount(<RecurseMyself times={900} />);
+    }).not.toThrow();
+  });
+
   it('can output structured debug strings', () => {
     const wrapper = mount(
       <div>
@@ -26,7 +37,7 @@ describe('@shopify/preact-testing', () => {
 </div>`,
     );
   });
-  
+
   it('can find dom components', () => {
     const wrapper = mount(
       <div>
@@ -299,7 +310,6 @@ describe('@shopify/preact-testing', () => {
       expect(myComponent.text()).toBe(myComponent.find(Message)!.text());
     });
 
-
     it('can find text directly inside a fragment', () => {
       function FragMessage({children}: {children?: ComponentChild}) {
         return <Fragment>{children}</Fragment>;
@@ -412,6 +422,42 @@ describe('@shopify/preact-testing', () => {
 
       const wrapper = mountWithContext(<Message />);
       expect(spy.mock.calls).toEqual([['render'], ['render'], ['afterMount']]);
+    });
+
+    it('waits on an async afterMount', async () => {
+      const AppContext = createContext('not the right message');
+      const mountWithContext = createMount<
+        {message: string},
+        {message: string}
+      >({
+        context: ({message}) => ({message}),
+        render: (vdom, context) => {
+          return (
+            <AppContext.Provider value={context.message}>
+              {vdom}
+            </AppContext.Provider>
+          );
+        },
+        afterMount: async (root) => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              root.context.message = 'a different message';
+              root.forceUpdate();
+              resolve();
+            }, 10);
+          });
+        },
+      });
+
+      function ContextMessage() {
+        const message = useContext(AppContext);
+        return <div>{message}</div>;
+      }
+
+      const wrapperPromise = mountWithContext(<ContextMessage />);
+      const wrapper = await wrapperPromise;
+      expect(wrapper.context.message).toBe('a different message');
+      expect(wrapper.html()).toBe(`<div>${wrapper.context.message}</div>`);
     });
   });
 });

--- a/src/tests/e2e.test.tsx
+++ b/src/tests/e2e.test.tsx
@@ -14,7 +14,7 @@ import {ComponentType} from '../types';
 
 describe('@shopify/preact-testing', () => {
   it('does not time out with large trees', () => {
-    function RecurseMyself({children, times}: any) {
+    function RecurseMyself({times}: {times: number}) {
       if (times <= 0) {
         return <div>finished</div>;
       }


### PR DESCRIPTION
## The problem
While trying to use this library in another project I encountered a lot of test timeouts. At first I thought it was due to async `afterMount` functions but upon inspection it was happening for literally any component that returned more than a few levels of nested vdom elements. 

## Solution
I added a test that reproduced the problem rendering nothing but an empty elemen 50 times around some text. I added some logs to `buildElementsFromVDom` to tell me how many times it was getting called and it was very clearly growing at a hilariously super-linear rate (126 times for 3 levels of tree depth). 

After a quick scan of the code I solved it via:
- fixing a careless choice where we recursed twice for every node (this fixes the heap size exceeding issues)
- used a basic for loop instead of a `reduce` to compile children arrays (this helps reduce callstack size which further increases our max depth)

## Concerns
We still can exceed the call stack if we get 1000s of levels deep but that's a problem with the react lib as well so it's for another time.