### PR TITLE
:fire: Remove react type dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/Shopify/preact-testing/blob/master/README.md",
   "dependencies": {
     "@shopify/useful-types": "^2.1.4",
-    "@types/react": "^16.9.23",
     "jest-matcher-utils": "^25.1.0"
   },
   "devDependencies": {

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -1,9 +1,5 @@
 import 'jest';
 import {ComponentType, Context as PreactContext} from 'preact';
-import {
-  ComponentType as ReactComponentType,
-  Context as ReactContext,
-} from 'react';
 import {Node, PropsFor} from '../types';
 
 import {toHaveProps, toHaveDataProps} from './props';
@@ -23,38 +19,28 @@ declare global {
         type: Type,
         props?: Partial<PropsFor<Type>>,
       ): void;
-      toContainComponent<Type extends string | ReactComponentType<any>>(
-        type: Type,
-        props?: Partial<PropsFor<Type>>,
-      ): void;
       toContainComponentTimes<Type extends string | ComponentType<any>>(
         type: Type,
         times: number,
         props?: Partial<PropsFor<Type>>,
       ): void;
-      toContainComponentTimes<Type extends string | ReactComponentType<any>>(
-        type: Type,
-        times: number,
-        props?: Partial<PropsFor<Type>>,
-      ): void;
       toProvideContext<Type>(context: PreactContext<Type>, value?: Type): void;
-      toProvideContext<Type>(context: ReactContext<Type>, value?: Type): void;
       toContainText(text: string): void;
       toContainHtml(text: string): void;
 
-      // compatibility APIs for react-testing
+      // compatibility APIs for @shopify/react-testing
       toHaveReactProps(props: Partial<PropsFromNode<R>>): void;
       toHaveReactDataProps(data: {[key: string]: string}): void;
-      toContainReactComponent<Type extends string | ReactComponentType<any>>(
+      toContainReactComponent<Type extends string | ComponentType<any>>(
         type: Type,
         props?: Partial<PropsFor<Type>>,
       ): void;
-      toContainReactComponentTimes<Type extends string | ReactComponentType<any>>(
+      toContainReactComponentTimes<Type extends string | ComponentType<any>>(
         type: Type,
         times: number,
         props?: Partial<PropsFor<Type>>,
       ): void;
-      toProvideReactContext<Type>(context: ReactContext<Type>, value?: Type): void;
+      toProvideReactContext<Type>(context: PreactContext<Type>, value?: Type): void;
       toContainReactText(text: string): void;
       toContainReactHtml(text: string): void;
     }


### PR DESCRIPTION
This PR removes the type dependency on React from this library. The overloaded methods were intended to make it easier to use this library in codebases that are aliasing Preact to React, but come at the cost of having this library bring in a dependency on `@types/react` that could potentially conflict with others. 

The type of projects these types were meant to support tend to do one of:
- alias `preact/compat`'s typing in their tsconfig
- allow TypeScript to be tricked into thinking they are using React
- not use Typescript

As such, I believe it makes more sense to simply expose the `to___React___` style APIs to support them and allow them to alias the package against `@shopify/react-testing` if they need to. 

I also added documentation for handling this usecase using aliasing to #12 

